### PR TITLE
Fix return type in getSelectedRange method

### DIFF
--- a/handsontable.d.ts
+++ b/handsontable.d.ts
@@ -1569,7 +1569,7 @@ declare namespace _Handsontable {
     getRowHeight(row: number): number;
     getSchema(): object;
     getSelected(): any[];
-    getSelectedRange(): Range;
+    getSelectedRange(): wt.CellRange;
     getSettings(): object;
     getSourceData(r?: number, c?: number, r2?: number, c2?: number): any[];
     getSourceDataArray(r?: number, c?: number, r2?: number, c2?: number): any[];


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Wrong return type of getSelectedRange method (Range).
 
### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
I used my application

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s):


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
